### PR TITLE
Create the Request class

### DIFF
--- a/Piko.php
+++ b/Piko.php
@@ -54,6 +54,15 @@ class Request
     {
         return $this->data[$key] ?? null;
     }
+
+    public static function get(): Request
+    {
+        return new self($_REQUEST);
+    }
+
+    public static function array(): array
+    {
+        return (array) static::get();
+    }
 }
 
-$request = new Request($_REQUEST);

--- a/Piko.php
+++ b/Piko.php
@@ -38,9 +38,9 @@ class Response
 
 class Request
 {
-    public array $data;
     public string $method;
     public string $path;
+    public array $data;
 
     public function __construct(array $data = [])
     {

--- a/Piko.php
+++ b/Piko.php
@@ -65,4 +65,3 @@ class Request
         return (array) static::get();
     }
 }
-

--- a/Piko.php
+++ b/Piko.php
@@ -2,7 +2,7 @@
 
 class Piko
 {
-    public const VERSION = '1.0.2';
+    public const VERSION = '1.1.0-dev';
 
     public static function boot(App $main, ?Closure $callback = null)
     {
@@ -35,3 +35,25 @@ class Response
         echo json_encode($response);
     }
 }
+
+class Request
+{
+    public array $data;
+    public string $method;
+    public string $path;
+
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+
+        $this->method = $_SERVER['REQUEST_METHOD'];
+        $this->path = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+    }
+
+    public function __get(string $key): ?string
+    {
+        return $this->data[$key] ?? null;
+    }
+}
+
+$request = new Request($_REQUEST);


### PR DESCRIPTION
Fixes #2 by adding a lightweight Request class. You can get a Request instance using `Request::get()`, or if you want it in array form, use `Request::array()`.

Example:
```php
class Main extends App
{
    public function handle(): Response
    {
        return new Response(200, 'OK', Request::array());
    }
}
```
Returns the following response when visiting `http://localhost/hello/world?foo=bar`
```json
{
  "statusCode": 200,
  "statusMessage": "OK",
  "method": "GET",
  "path": "/hello/world",
  "data": {
    "foo": "bar"
  }
}
```
Remember that sanitizing and validating any input data is up to you!